### PR TITLE
setup: set session=False to fix pip install

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 image: python2.7
 script:
+  - pip install -U pip
   - make test
 notify:
   email:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ reqs = './requirements.txt'
 if len(sys.argv) > 1 and sys.argv[1] in ['develop', 'test']:
   reqs = './requirements-dev.txt'
 
-install_reqs = parse_requirements(os.path.join(here, reqs))
+install_reqs = parse_requirements(os.path.join(here, reqs), session=False)
 
 setup(name='kayvee',
       version=version.VERSION,


### PR DESCRIPTION
context:
http://stackoverflow.com/questions/27869152/heroku-typeerror-parse-requirements-missing-1-required-keyword-argument-ses

relates to: https://github.com/Clever/kayvee-python/pull/4