### PR TITLE
Clever logger update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# repo specific
+tests/tests.json   # downloaded during test run
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,40 @@
-kayvee-python
-=============
+# kayvee-python
 
-Kayvee translates an dictionary into a human and machine parseable string, with a "key=val" format.
+Kayvee translates an dictionary into a human and machine parseable string, with a "json" format.
+
+## Usage
+
+The Kayvee formatter can be used directly or through the `kayvee.logger`
+
+### kayvee formatter
+
+```python
+import kayvee as kv
+
+print(kv.format(source="logger-test",
+                level=kv.INFO,
+                title="informational-log-title",
+                dict(id=name_id, context=context_str))
+```
+
+### kayvee.logger
+
+```python
+import kayvee.logger
+
+logger.Logger("logger-test")
+logger.infoD("information-log-title", dict(id=name_id, context=context_str)
+```
+
+Other functions supported for structured logging:
+
+* `logger.debug`
+* `logger.info`
+* `logger.warn`
+* `logger.error`
+* `logger.critical`
+
+Supported metrics:
+
+* `logger.counter`
+* `logger.gauge`

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -21,32 +21,32 @@ LOG_LEVEL_ENUM = {
 
 # This is a port from kayvee-go/logger/logger.go
 class Logger:
-  def __init__(self, source, logLvl=None, formatter=kv.format, output=sys.stderr):
-    if not logLvl:
-      logLvl = os.environ.get('KAYVEE_LOG_LEVEL')
-    self.logLvl = self._validateLogLvl(logLvl)
+  def __init__(self, source, log_level=None, formatter=kv.format, output=sys.stderr):
+    if not log_level:
+      log_level = os.environ.get('KAYVEE_LOG_LEVEL')
+    self.log_level = self._validateLogLevel(log_level)
     self.globals = {}
     self.globals["source"] = source
     self.formatter = formatter
     self.output = output
 
-  def setConfig(self, source, logLvl, formatter, output):
+  def setConfig(self, source, log_level, formatter, output):
     self.globals["source"] = source
-    self.logLvl = self._validateLogLvl(logLvl)
+    self.log_level = self._validateLogLevel(log_level)
     self.formatter = formatter
     self.output = output
 
-  def _validateLogLvl(self, logLvl):
-    if not logLvl:
+  def _validateLogLevel(self, log_level):
+    if not log_level:
       return LOG_LEVELS["Debug"]
     else:
       for key, value in LOG_LEVELS.iteritems():
-        if logLvl.lower() == value:
+        if log_level.lower() == value:
           return value
     return LOG_LEVELS["Debug"]
 
-  def setLogLevel(self, logLvl):
-    self.logLvl = self._validateLogLvl(logLvl)
+  def setLogLevel(self, log_level):
+    self.log_level = self._validateLogLevel(log_level)
 
   def setFormatter(self, formatter):
     self.formatter = formatter
@@ -107,10 +107,10 @@ class Logger:
     data["type"] = "gauge"
     self.logWithLevel(LOG_LEVELS["Info"], data)
 
-  def logWithLevel(self, logLvl, data):
-    if LOG_LEVEL_ENUM[logLvl] < LOG_LEVEL_ENUM[self.logLvl]:
+  def logWithLevel(self, log_level, data):
+    if LOG_LEVEL_ENUM[log_level] < LOG_LEVEL_ENUM[self.log_level]:
       return
-    data["level"] = logLvl
+    data["level"] = log_level
     for key,value in self.globals.iteritems():
       if key in data:
         continue

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -25,13 +25,13 @@ class Logger:
     if not log_level:
       log_level = os.environ.get('KAYVEE_LOG_LEVEL')
     self.log_level = self._validateLogLevel(log_level)
-    self.globals = {}
-    self.globals["source"] = source
+    self.default_fields = {}
+    self.default_fields["source"] = source
     self.formatter = formatter
     self.output = output
 
   def setConfig(self, source, log_level, formatter, output):
-    self.globals["source"] = source
+    self.default_fields["source"] = source
     self.log_level = self._validateLogLevel(log_level)
     self.formatter = formatter
     self.output = output
@@ -54,54 +54,40 @@ class Logger:
   def setOutput(self, output):
     self.output = output
 
-  def debug(self, title):
-    self.debugD(title, {})
-
-  def info(self, title):
-    self.infoD(title, {})
-
-  def warn(self, title):
-    self.warnD(title, {})
-
-  def error(self, title):
-    self.errorD(title, {})
-
-  def critical(self, title):
-    self.criticalD(title, {})
-
-  def counter(self, title):
-    self.counterD(title, 1, {})
-
-  def gauge(self, title, value):
-    self.gaugeD(title, value, {})
-
-  def debugD(self, title, data):
+  def debug(self, title, data=None):
+    data = data if data else {}
     data["title"] = title
     self.logWithLevel(LOG_LEVELS["Debug"], data)
 
-  def infoD(self, title, data):
+  def info(self, title, data=None):
+    data = data if data else {}
     data["title"] = title
     self.logWithLevel(LOG_LEVELS["Info"], data)
 
-  def warnD(self, title, data):
+  def warn(self, title, data=None):
+    data = data if data else {}
     data["title"] = title
     self.logWithLevel(LOG_LEVELS["Warning"], data)
 
-  def errorD(self, title, data):
+  def error(self, title, data=None):
+    data = data if data else {}
     data["title"] = title
     self.logWithLevel(LOG_LEVELS["Error"], data)
 
-  def criticalD(self, title, data):
+  def critical(self, title, data=None):
+    data = data if data else {}
     data["title"] = title
     self.logWithLevel(LOG_LEVELS["Critical"], data)
 
-  def counterD(self, title, value, data):
+  def counter(self, title, value=1, data=None):
+    data = data if data else {}
     data["title"] = title
     data["value"] = value
     data["type"] = "counter"
     self.logWithLevel(LOG_LEVELS["Info"], data)
 
-  def gaugeD(self, title, value, data):
+  def gauge(self, title, value, data=None):
+    data = data if data else {}
     data["title"] = title
     data["value"] = value
     data["type"] = "gauge"
@@ -111,9 +97,9 @@ class Logger:
     if LOG_LEVEL_ENUM[log_level] < LOG_LEVEL_ENUM[self.log_level]:
       return
     data["level"] = log_level
-    for key,value in self.globals.iteritems():
+    for key,value in self.default_fields.iteritems():
       if key in data:
         continue
       data[key] = value
     logString = self.formatter(data)
-    print(logString, file=self.output)
+    self.output.write(logString + "\n")

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -32,28 +32,28 @@ class TestLogger(unittest.TestCase):
     self.assertEqual(outputIO.getvalue(), expected)
     outputIO.close()
 
-  def test_validateLogLvl(self):
+  def test_validateLogLevel(self):
     # Explicit validation checks
     logObj = logger.Logger("logger-tester")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
     # Test case-insensitive in log level name
-    logLvl = logObj._validateLogLvl("debug")
-    self.assertEqual(logLvl, logger.LOG_LEVELS["Debug"])
-    logLvl = logObj._validateLogLvl("Debug")
-    self.assertEqual(logLvl, logger.LOG_LEVELS["Debug"])
+    log_level = logObj._validateLogLevel("debug")
+    self.assertEqual(log_level, logger.LOG_LEVELS["Debug"])
+    log_level = logObj._validateLogLevel("Debug")
+    self.assertEqual(log_level, logger.LOG_LEVELS["Debug"])
 
     # Test non-default log levels
-    logLvl = logObj._validateLogLvl("info")
-    self.assertEqual(logLvl, logger.LOG_LEVELS["Info"])
-    logLvl = logObj._validateLogLvl("critical")
-    self.assertEqual(logLvl, logger.LOG_LEVELS["Critical"])
+    log_level = logObj._validateLogLevel("info")
+    self.assertEqual(log_level, logger.LOG_LEVELS["Info"])
+    log_level = logObj._validateLogLevel("critical")
+    self.assertEqual(log_level, logger.LOG_LEVELS["Critical"])
     # TODO: add for each possible level
 
     # Test sets level to debug if given invalid log level
-    logLvl = logObj._validateLogLvl("sometest")
-    self.assertEqual(logLvl, logger.LOG_LEVELS["Debug"])
+    log_level = logObj._validateLogLevel("sometest")
+    self.assertEqual(log_level, logger.LOG_LEVELS["Debug"])
     outputIO.close()
 
   def test_invalidLog(self):
@@ -62,7 +62,7 @@ class TestLogger(unittest.TestCase):
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
-    logObj.setLogLevel("invalidloglvl")
+    logObj.setLogLevel("invalidlog_level")
     logObj.debug("testlogdebug")
     expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Debug"] + "\", \"title\": \"testlogdebug\"}"
     self.assertEqualJson(outputIO.getvalue(), expected)
@@ -88,21 +88,21 @@ class TestLogger(unittest.TestCase):
         logger.LOG_LEVELS["Critical"]: (logObj.critical, logObj.criticalD)
     }
 
-    for logLvl in tests:
+    for log_level in tests:
         outputIO = StringIO.StringIO()
         logObj.setOutput(outputIO)
 
-        simpleLogFunc = tests[logLvl][0]
-        simpleLogFunc("testlog"+logLvl)
-        simpleExpected = "{\"source\": \"logger-tester\", \"level\": \"" + logLvl + "\", \"title\": \"testlog" + logLvl + "\"}"
+        simpleLogFunc = tests[log_level][0]
+        simpleLogFunc("testlog"+log_level)
+        simpleExpected = "{\"source\": \"logger-tester\", \"level\": \"" + log_level + "\", \"title\": \"testlog" + log_level + "\"}"
         self.assertEqualJson(outputIO.getvalue(), simpleExpected)
 
         outputIO = StringIO.StringIO()
         logObj.setOutput(outputIO)
 
-        addlDataLogFunc = tests[logLvl][1]
-        addlDataLogFunc("testlog"+logLvl, {"key1":"val1","key2":"val2"})
-        addlDataExpected = "{\"source\": \"logger-tester\", \"level\": \"" + logLvl + "\", \"title\": \"testlog" + logLvl + "\",\"key1\": \"val1\", \"key2\": \"val2\"}"
+        addlDataLogFunc = tests[log_level][1]
+        addlDataLogFunc("testlog"+log_level, {"key1":"val1","key2":"val2"})
+        addlDataExpected = "{\"source\": \"logger-tester\", \"level\": \"" + log_level + "\", \"title\": \"testlog" + log_level + "\",\"key1\": \"val1\", \"key2\": \"val2\"}"
         self.assertEqualJson(outputIO.getvalue(), addlDataExpected)
 
     outputIO.close()

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -19,22 +19,22 @@ class TestLogger(unittest.TestCase):
     expected = json.loads(b)
     self.assertNotEqual(actual, expected)
 
-  def test_constructor(self):
+  def test_logger_contruct(self):
     formatter = lambda data: data["level"] + "." + data["source"] + "." + data["title"]
     outputIO = StringIO.StringIO()
-    logObj = logger.Logger("logger-test", logger.LOG_LEVELS["Info"], formatter, outputIO)
+    logObj = logger.Logger("logger-constructor", logger.LOG_LEVELS["Info"], formatter, outputIO)
     logObj.debug("testlogdebug")
     expected = ""
     self.assertEqual(outputIO.getvalue(), expected)
 
     logObj.info("testloginfo")
-    expected = logger.LOG_LEVELS["Info"] + ".logger-test.testloginfo\n"
+    expected = logger.LOG_LEVELS["Info"] + ".logger-constructor.testloginfo\n"
     self.assertEqual(outputIO.getvalue(), expected)
     outputIO.close()
 
   def test_validateLogLevel(self):
     # Explicit validation checks
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-validateLogLevel")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
@@ -58,34 +58,35 @@ class TestLogger(unittest.TestCase):
 
   def test_invalidLog(self):
     # Invalid log levels will default to debug
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-invalidLog")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
     logObj.setLogLevel("invalidlog_level")
-    logObj.debug("testlogdebug")
-    expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Debug"] + "\", \"title\": \"testlogdebug\"}"
+    logObj.debug("debug-invalidlog")
+    expected = "{\"source\": \"logger-invalidLog\", \"level\": \"" + logger.LOG_LEVELS["Debug"] + "\", \"title\": \"debug-invalidlog\"}"
     self.assertEqualJson(outputIO.getvalue(), expected)
+    outputIO.close()
 
     # Recreate to clear
-    outputIO = StringIO.StringIO()
+    outputIO = StringIO.StringIO("")
     logObj.setOutput(outputIO)
     logObj.setLogLevel("sometest")
-    logObj.info("testloginfo")
-    expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloginfo\"}"
+    logObj.info("info-invalidlog")
+    expected = "{\"source\": \"logger-invalidLog\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"info-invalidlog\"}"
     self.assertEqualJson(outputIO.getvalue(), expected)
     outputIO.close()
 
   def test_logFuncs(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-logFuncs")
 
-    # LOG_LEVEL: (simpleLogFunc, addlDataLogFunc)
+    # LOG_LEVEL: (withoutData, withData)
     tests = {
-        logger.LOG_LEVELS["Debug"]: (logObj.debug, logObj.debugD),
-        logger.LOG_LEVELS["Info"]: (logObj.info, logObj.infoD),
-        logger.LOG_LEVELS["Warning"]: (logObj.warn, logObj.warnD),
-        logger.LOG_LEVELS["Error"]: (logObj.error, logObj.errorD),
-        logger.LOG_LEVELS["Critical"]: (logObj.critical, logObj.criticalD)
+        logger.LOG_LEVELS["Debug"]: (logObj.debug, logObj.debug),
+        logger.LOG_LEVELS["Info"]: (logObj.info, logObj.info),
+        logger.LOG_LEVELS["Warning"]: (logObj.warn, logObj.warn),
+        logger.LOG_LEVELS["Error"]: (logObj.error, logObj.error),
+        logger.LOG_LEVELS["Critical"]: (logObj.critical, logObj.critical)
     }
 
     for log_level in tests:
@@ -94,76 +95,75 @@ class TestLogger(unittest.TestCase):
 
         simpleLogFunc = tests[log_level][0]
         simpleLogFunc("testlog"+log_level)
-        simpleExpected = "{\"source\": \"logger-tester\", \"level\": \"" + log_level + "\", \"title\": \"testlog" + log_level + "\"}"
+        simpleExpected = "{\"source\": \"logger-logFuncs\", \"level\": \"" + log_level + "\", \"title\": \"testlog" + log_level + "\"}"
         self.assertEqualJson(outputIO.getvalue(), simpleExpected)
+
+        outputIO.close()
 
         outputIO = StringIO.StringIO()
         logObj.setOutput(outputIO)
 
         addlDataLogFunc = tests[log_level][1]
         addlDataLogFunc("testlog"+log_level, {"key1":"val1","key2":"val2"})
-        addlDataExpected = "{\"source\": \"logger-tester\", \"level\": \"" + log_level + "\", \"title\": \"testlog" + log_level + "\",\"key1\": \"val1\", \"key2\": \"val2\"}"
+        addlDataExpected = "{\"source\": \"logger-logFuncs\", \"level\": \"" + log_level + "\", \"title\": \"testlog" + log_level + "\",\"key1\": \"val1\", \"key2\": \"val2\"}"
         self.assertEqualJson(outputIO.getvalue(), addlDataExpected)
 
-    outputIO.close()
+        outputIO.close()
 
   def test_counter(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-counter")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
     logObj.counter("testlogcounter")
-    expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testlogcounter\", \"type\": \"counter\", \"value\": 1}"
+    expected = "{\"source\": \"logger-counter\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testlogcounter\", \"type\": \"counter\", \"value\": 1}"
     self.assertEqualJson(outputIO.getvalue(), expected)
     outputIO.close()
-  def test_counterD(self):
-    logObj = logger.Logger("logger-tester")
+
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
-
-    logObj.counterD("testlogcounter", 2, {"key1":"val1","key2":"val2"})
-    expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testlogcounter\",\"type\": \"counter\", \"value\": 2,\"key1\": \"val1\", \"key2\": \"val2\"}"
+    logObj.counter("testlogcounter", 2, {"key1":"val1","key2":"val2"})
+    expected = "{\"source\": \"logger-counter\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testlogcounter\",\"type\": \"counter\", \"value\": 2,\"key1\": \"val1\", \"key2\": \"val2\"}"
     self.assertEqualJson(outputIO.getvalue(), expected)
     outputIO.close()
 
   def test_gauge(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-gauge")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
     logObj.gauge("testloggauge", 0)
-    expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloggauge\", \"type\": \"gauge\", \"value\": 0}"
+    expected = "{\"source\": \"logger-gauge\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloggauge\", \"type\": \"gauge\", \"value\": 0}"
     self.assertEqualJson(outputIO.getvalue(), expected)
     outputIO.close()
-  def test_gaugeD(self):
-    logObj = logger.Logger("logger-tester")
+
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
-
-    logObj.gaugeD("testloggauge", 4, {"key1":"val1","key2":"val2"})
-    expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloggauge\", \"type\": \"gauge\", \"value\": 4, \"key1\": \"val1\", \"key2\": \"val2\"}"
+    logObj.gauge("testloggauge", 4, {"key1":"val1","key2":"val2"})
+    expected = "{\"source\": \"logger-gauge\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloggauge\", \"type\": \"gauge\", \"value\": 4, \"key1\": \"val1\", \"key2\": \"val2\"}"
     self.assertEqualJson(outputIO.getvalue(), expected)
     outputIO.close()
 
   def test_diffOutput(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-diffOutput")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
-    logObj.info("testloginfo")
+    logObj.info("info-diffOutput")
     output1 = outputIO.getvalue()
 
     outputIO2 = StringIO.StringIO()
     logObj.setOutput(outputIO2)
-    logObj.warn("testlogwarning")
+    logObj.warn("warn-diffOutput")
     output2 = outputIO2.getvalue()
 
     self.assertEqualJson(output1, outputIO.getvalue())
     self.assertNotEqualJson(output2, outputIO.getvalue())
     outputIO.close()
+    outputIO2.close()
 
   def test_hiddenLogWarning(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-hiddenLogWarning")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
     logObj.setLogLevel(logger.LOG_LEVELS["Warning"])
@@ -185,7 +185,7 @@ class TestLogger(unittest.TestCase):
     outputIO.close()
 
   def test_hiddenLogCritical(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-hiddenLogCritical")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
     logObj.setLogLevel(logger.LOG_LEVELS["Critical"])
@@ -207,7 +207,7 @@ class TestLogger(unittest.TestCase):
     outputIO.close()
 
   def test_diffFormat(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-diffFormat")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
     logObj.setFormatter(lambda data: "\"This is a test\"")
@@ -216,33 +216,34 @@ class TestLogger(unittest.TestCase):
     outputIO.close()
 
   def test_multipleLoggers(self):
-    logObj = logger.Logger("logger-tester")
+    logObj = logger.Logger("logger-multipleLoggers-1")
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
 
     # Same buffer
-    logObj2 = logger.Logger("logger-tester2")
+    logObj2 = logger.Logger("logger-multipleLoggers-2")
     logObj2.setOutput(outputIO)
     logObj.warn("testlogwarning")
     output1 = outputIO.getvalue()
     logObj2.info("testloginfo")
     output2 = outputIO.getvalue()
     self.assertNotEqual(output1, output2)
+    outputIO.close()
 
     # Recreate to clear
     outputIO = StringIO.StringIO()
     logObj.setOutput(outputIO)
+    logObj.warn("testlogwarning")
 
     # Different buffer
     outputIO2 = StringIO.StringIO()
     logObj2.setOutput(outputIO2)
-    logObj.warn("testlogwarning")
     logObj2.info("testloginfo")
 
-    loggerExpected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.LOG_LEVELS["Warning"] + "\", \"title\": \"testlogwarning\"}"
+    loggerExpected = "{\"source\": \"logger-multipleLoggers-1\", \"level\": \"" + logger.LOG_LEVELS["Warning"] + "\", \"title\": \"testlogwarning\"}"
     self.assertEqualJson(outputIO.getvalue(), loggerExpected)
 
-    logger2Expected = "{\"source\": \"logger-tester2\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloginfo\"}"
+    logger2Expected = "{\"source\": \"logger-multipleLoggers-2\", \"level\": \"" + logger.LOG_LEVELS["Info"] + "\", \"title\": \"testloginfo\"}"
     self.assertEqualJson(outputIO2.getvalue(), logger2Expected)
     outputIO.close()
     outputIO2.close()


### PR DESCRIPTION
- use default arguments to make the interface more pythonic
- change tests so that they use specific sources making it easier to
  debug if tests fail
- add a readme
- logLvl -> log_level
- add tests/tests.json to gitignore