### PR TITLE
update publish to work now that old way is obsolete, also fix pypi long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ When you merge changes for a new version:
 - bump the `VERSION`
 - update `CHANGELOG.md` explaining the changes
 - after merging, run `publish.sh`
+    - requires you to install twine and wheel via `pip install <package>`
     - creates a git tag associating the version with the commit
-    - publishes the versioned package to pypi (Python package store;
-        this requires that you have the correct permissions to publish)
+    - publishes the versioned package to pypi (Python package store)
 
 If you have any issues, please work with `#oncall-infra`.

--- a/publish.sh
+++ b/publish.sh
@@ -2,9 +2,8 @@
 
 # Publishes package to pypi and creates git tags.
 # Reads version from VERSION file.
-#
-# To register a package (before first publish):
-#   python setup.py register
+
+set -eo pipefail
 
 version=`cat VERSION`
 changelog=CHANGELOG.md
@@ -17,8 +16,9 @@ fi
 read -p "Publish and tag as v$version? " -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   # publish to pypi
-  python3 setup.py sdist upload
-
+  python3 setup.py sdist bdist_wheel
+  twine check dist/*
+  TWINE_PASSWORD=$(ark secrets read production.kayvee-python pypi-publish-token | sed -n 2p) twine upload dist/* -u __token__
   # create git tags
   git tag -a v$version -m "version $version"
   git push --tags

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,14 @@ from builtins import str
 import os
 import sys
 from setuptools import setup, find_packages
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
+from pip._internal.req import parse_requirements
 import version
-import pkg_resources
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
-  with open(os.path.join(here, '../README.md')) as f:
+  with open(os.path.join(here, 'README.md')) as f:
     README = f.read()
-  with open(os.path.join(here, '../CHANGES.md')) as f:
+  with open(os.path.join(here, 'CHANGELOG.md')) as f:
     CHANGES = f.read()
 except:
   README = ''
@@ -36,8 +32,10 @@ setup(name='kayvee',
       author_email='tech-notify@getclever.com',
       url='https://github.com/Clever/kayvee-python/',
       long_description=README + '\n\n' + CHANGES,
+      long_description_content_type='text/markdown',
       packages=find_packages(exclude=['*.tests']),
       install_requires=[str(ir.requirement) for ir in install_reqs],
       setup_requires=['nose>=1.0'],
       test_suite='test',
+      python_requires='>=3.9.12',
       )


### PR DESCRIPTION
These changes have been tested with `TWINE_PASSWORD=$(ark secrets read production.kayvee-python pypi-publish-token | sed -n 2p) twine upload dist/* -u __token__`

I wanted to get README changes pushed before actually testing the publish step!

I created a new token using our pypi account in 1Password and added that token as a secret in 1 password. 

As kayvee-python is not an app (it is a library) we have to do `sed -n 2p`. I tested that `TWINE_PASSWORD=$(ark secrets read production.kayvee-python pypi-publish-token | sed -n 2p)` works correctly so the hope is that this works!

Docs
https://twine.readthedocs.io/en/stable/
https://pypi.org/help/#apitoken