### PR TITLE
decode byte string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
 import pkg_resources
 
 version_file = pkg_resources.resource_stream(__name__, "VERSION")
-VERSION = version_file.readline().strip()
+VERSION = version_file.readline().decode("utf-8").strip()


### PR DESCRIPTION
python 3 is specific about bytes vs string. This is why publish was trying to use `b'3.0.0'` which translated to `b-3.0.0-` and failed to publish.

This change should fix this issue